### PR TITLE
Add minimal dual-stack support, better server IP detection and misc fixes

### DIFF
--- a/config.py
+++ b/config.py
@@ -1,4 +1,5 @@
 PORT = 3256
+PREFER_IPV6 = False
 
 # name -> secret (32 hex chars)
 USERS = {

--- a/mtprotoproxy.py
+++ b/mtprotoproxy.py
@@ -238,7 +238,7 @@ def print_tg_info():
         params = {
             "server": my_ip, "port": PORT, "secret": secret
         }
-        print("tg://proxy?" + urllib.parse.urlencode(params), flush=True)
+        print("{}: tg://proxy?{}".format(user, urllib.parse.urlencode(params)), flush=True)
 
 
 def main():

--- a/mtprotoproxy.py
+++ b/mtprotoproxy.py
@@ -238,7 +238,7 @@ def print_tg_info():
         params = {
             "server": my_ip, "port": PORT, "secret": secret
         }
-        print("{}: tg://proxy?{}".format(user, urllib.parse.urlencode(params)), flush=True)
+        print("{}: tg://proxy?{}".format(user, urllib.parse.urlencode(params, safe=':')), flush=True)
 
 
 def main():

--- a/mtprotoproxy.py
+++ b/mtprotoproxy.py
@@ -25,11 +25,19 @@ except ModuleNotFoundError:
         return pyaes.AESModeOfOperationCTR(key, ctr)
 
 
-from config import PORT, USERS
+from config import PORT, PREFER_IPV6, USERS
 
-TG_DATACENTERS = [
+TG_DATACENTERS_V4 = [
     "149.154.175.50", "149.154.167.51", "149.154.175.100",
     "149.154.167.91", "149.154.171.5"
+]
+
+TG_DATACENTERS_V6 = [
+    "2001:0b28:f23d:f001:0000:0000:0000:000a",
+    "2001:067c:04e8:f002:0000:0000:0000:000a",
+    "2001:0b28:f23d:f003:0000:0000:0000:000a",
+    "2001:067c:04e8:f004:0000:0000:0000:000a",
+    "2001:0b28:f23f:f005:0000:0000:0000:000a",
 ]
 
 TG_DATACENTER_PORT = 443
@@ -88,10 +96,13 @@ async def handle_handshake(reader, writer):
 
         dc_idx = abs(int.from_bytes(decrypted[60:62], "little", signed=True)) - 1
 
-        if dc_idx < 0 or dc_idx >= len(TG_DATACENTERS):
+        if dc_idx < 0 or dc_idx >= len(TG_DATACENTERS_V4) or dc_idx >= len(TG_DATACENTERS_V6):
             continue
 
-        dc = TG_DATACENTERS[dc_idx]
+        if PREFER_IPV6:
+            dc = TG_DATACENTERS_V6[dc_idx]
+        else:
+            dc = TG_DATACENTERS_V4[dc_idx]
 
         return encryptor, decryptor, user, dc, enc_key + enc_iv
     return False

--- a/mtprotoproxy.py
+++ b/mtprotoproxy.py
@@ -234,7 +234,7 @@ def print_tg_info():
     except:
         my_ip = 'YOUR_IP'
 
-    for user, secret in USERS.items():
+    for user, secret in sorted(USERS.items(), key=lambda x: x[0]):
         params = {
             "server": my_ip, "port": PORT, "secret": secret
         }

--- a/mtprotoproxy.py
+++ b/mtprotoproxy.py
@@ -3,6 +3,7 @@
 import asyncio
 import socket
 import urllib.parse
+import urllib.request
 import collections
 import time
 import hashlib
@@ -226,17 +227,12 @@ async def stats_printer():
 
 
 def print_tg_info():
-    my_ip = socket.gethostbyname(socket.gethostname())
-
-    octets = [int(o) for o in my_ip.split(".")]
-
-    ip_is_local = (len(octets) == 4 and (
-        octets[0] in [127, 10] or
-        octets[0:2] == [192, 168] or
-        (octets[0] == 172 and 16 <= octets[1] <= 31)))
-
-    if ip_is_local:
-        my_ip = "YOUR_IP"
+    try:
+        with urllib.request.urlopen('https://ifconfig.co/ip') as f:
+            if f.status != 200: raise Exception("Invalid status code")
+            my_ip = f.read().strip()
+    except:
+        my_ip = 'YOUR_IP'
 
     for user, secret in USERS.items():
         params = {


### PR DESCRIPTION
* Add dual-stack support by maintaining a separate IPv6 socket (`IPV6_V6ONLY=0` won't work in OpenBSD, hence a separate socket)
* Add support for communicating with datacenters over IPv6, this has to be activated by the user
* Use an external service to determine server's IP address, this helps if server is behind NAT
* Print user ID next to each proxy link for ease of identification