### PR TITLE
unless-stopped instead of always restart type

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,6 @@ version: '2.0'
 services:
   mtprotoproxy:
     build: .
-    restart: always
+    restart: unless-stopped
     mem_limit: 1024m
     network_mode: "host"


### PR DESCRIPTION
it is easy to use, also you can stop proxy and start again without removing it docker image