### PR TITLE
[WIP] Support intermediate protocol (as used by tdlib)

### DIFF
--- a/mtprotoproxy.py
+++ b/mtprotoproxy.py
@@ -119,10 +119,11 @@ PREKEY_LEN = 32
 KEY_LEN = 32
 IV_LEN = 16
 HANDSHAKE_LEN = 64
-MAGIC_VAL_POS = 56
+PROTO_TAG_POS = 56
 DC_IDX_POS = 60
 
-MAGIC_VAL_TO_CHECK = b'\xef\xef\xef\xef'
+PROTO_TAG_ABRIDGED = b'\xef\xef\xef\xef'
+PROTO_TAG_INTERMEDIATE = b'\xee\xee\xee\xee'
 
 CBC_PADDING = 16
 PADDING_FILLER = b"\x04\x00\x00\x00"
@@ -418,19 +419,20 @@ async def handle_handshake(reader, writer):
 
         decrypted = decryptor.decrypt(handshake)
 
-        check_val = decrypted[MAGIC_VAL_POS:MAGIC_VAL_POS+4]
-        if check_val != MAGIC_VAL_TO_CHECK:
+        proto_tag = decrypted[PROTO_TAG_POS:PROTO_TAG_POS+4]
+        if proto_tag not in (PROTO_TAG_ABRIDGED, PROTO_TAG_INTERMEDIATE):
+            print_err('unsupported protocol tag: {}'.format(binascii.hexlify(proto_tag)))
             continue
 
         dc_idx = int.from_bytes(decrypted[DC_IDX_POS:DC_IDX_POS+2], "little", signed=True)
 
         reader = CryptoWrappedStreamReader(reader, decryptor)
         writer = CryptoWrappedStreamWriter(writer, encryptor)
-        return reader, writer, user, dc_idx, enc_key + enc_iv
+        return reader, writer, proto_tag, user, dc_idx, enc_key + enc_iv
     return False
 
 
-async def do_direct_handshake(dc_idx, dec_key_and_iv=None):
+async def do_direct_handshake(proto_tag, dc_idx, dec_key_and_iv=None):
     RESERVED_NONCE_FIRST_CHARS = [b"\xef"]
     RESERVED_NONCE_BEGININGS = [b"\x48\x45\x41\x44", b"\x50\x4F\x53\x54",
                                 b"\x47\x45\x54\x20", b"\xee\xee\xee\xee"]
@@ -467,7 +469,7 @@ async def do_direct_handshake(dc_idx, dec_key_and_iv=None):
             continue
         break
 
-    rnd[MAGIC_VAL_POS:MAGIC_VAL_POS+4] = MAGIC_VAL_TO_CHECK
+    rnd[PROTO_TAG_POS:PROTO_TAG_POS+4] = proto_tag
 
     if dec_key_and_iv:
         rnd[SKIP_LEN:SKIP_LEN+KEY_LEN+IV_LEN] = dec_key_and_iv[::-1]
@@ -482,7 +484,7 @@ async def do_direct_handshake(dc_idx, dec_key_and_iv=None):
     enc_key, enc_iv = enc_key_and_iv[:KEY_LEN], enc_key_and_iv[KEY_LEN:]
     encryptor = create_aes_ctr(key=enc_key, iv=int.from_bytes(enc_iv, "big"))
 
-    rnd_enc = rnd[:MAGIC_VAL_POS] + encryptor.encrypt(rnd)[MAGIC_VAL_POS:]
+    rnd_enc = rnd[:PROTO_TAG_POS] + encryptor.encrypt(rnd)[PROTO_TAG_POS:]
 
     writer_tgt.write(rnd_enc)
     await writer_tgt.drain()
@@ -674,15 +676,15 @@ async def handle_client(reader_clt, writer_clt):
         writer_clt.transport.abort()
         return
 
-    reader_clt, writer_clt, user, dc_idx, enc_key_and_iv = clt_data
+    reader_clt, writer_clt, proto_tag, user, dc_idx, enc_key_and_iv = clt_data
 
     update_stats(user, connects=1)
 
     if not USE_MIDDLE_PROXY:
         if FAST_MODE:
-            tg_data = await do_direct_handshake(dc_idx, dec_key_and_iv=enc_key_and_iv)
+            tg_data = await do_direct_handshake(proto_tag, dc_idx, dec_key_and_iv=enc_key_and_iv)
         else:
-            tg_data = await do_direct_handshake(dc_idx)
+            tg_data = await do_direct_handshake(proto_tag, dc_idx)
     else:
         cl_ip, cl_port = writer_clt.upstream.get_extra_info('peername')[:2]
         tg_data = await do_middleproxy_handshake(dc_idx, cl_ip, cl_port)

--- a/mtprotoproxy.py
+++ b/mtprotoproxy.py
@@ -782,7 +782,7 @@ async def handle_client(reader_clt, writer_clt):
             writer_clt = MTProtoIntermediateFrameStreamWriter(writer_clt)
             FLAGHACKS[peer] |= RpcFlags.PROTOCOL_INTERMEDIATE
 
-    async def connect_reader_to_writer(rd, wr, user):
+    async def connect_reader_to_writer(rd, wr, peer, user):
         update_stats(user, curr_connects_x2=1)
         try:
             while True:
@@ -801,10 +801,11 @@ async def handle_client(reader_clt, writer_clt):
             pass
         finally:
             wr.transport.abort()
+            del FLAGHACKS[peer]
             update_stats(user, curr_connects_x2=-1)
 
-    asyncio.ensure_future(connect_reader_to_writer(reader_tg, writer_clt, user))
-    asyncio.ensure_future(connect_reader_to_writer(reader_clt, writer_tg, user))
+    asyncio.ensure_future(connect_reader_to_writer(reader_tg, writer_clt, peer, user))
+    asyncio.ensure_future(connect_reader_to_writer(reader_clt, writer_tg, peer, user))
 
 
 async def handle_client_wrapper(reader, writer):

--- a/mtprotoproxy.py
+++ b/mtprotoproxy.py
@@ -125,6 +125,8 @@ DC_IDX_POS = 60
 PROTO_TAG_ABRIDGED = b'\xef\xef\xef\xef'
 PROTO_TAG_INTERMEDIATE = b'\xee\xee\xee\xee'
 
+RPC_FLAG_QUICKACK = 0x80000000
+
 CBC_PADDING = 16
 PADDING_FILLER = b"\x04\x00\x00\x00"
 
@@ -341,7 +343,14 @@ class MTProtoCompactFrameStreamWriter(LayeredStreamWriterBase):
 class MTProtoIntermediateFrameStreamReader(LayeredStreamReaderBase):
     async def read(self, buf_size):
         msg_len_bytes = await self.upstream.readexactly(4)
+
+        print(f'raw msg length: {binascii.hexlify(msg_len_bytes)}')
         msg_len = int.from_bytes(msg_len_bytes, "little")
+
+        if msg_len & RPC_FLAG_QUICKACK:
+            # just ignore this for now
+            msg_len &= ~RPC_FLAG_QUICKACK
+
         print(f'parsing medium packet, len: {msg_len}');
 
         data = await self.upstream.readexactly(msg_len)

--- a/mtprotoproxy.py
+++ b/mtprotoproxy.py
@@ -132,7 +132,6 @@ class RpcFlags(enum.Flag):
     HAS_AD_TAG            =        0x8
     MAGIC                 =     0x1000
     EXTMODE2              =    0x20000
-    DROPPED               = 0x10000000
     PROTOCOL_INTERMEDIATE = 0x20000000
     PROTOCOL_ABRIDGED     = 0x40000000
     QUICKACK              = 0x80000000

--- a/mtprotoproxy.py
+++ b/mtprotoproxy.py
@@ -322,7 +322,7 @@ class MTProtoCompactFrameStreamReader(LayeredStreamReaderBase):
             quickack = RpcFlags.QUICKACK
             msg_len -= 0x80
         else:
-            quickack = 0
+            quickack = RpcFlags.NONE
 
         FLAGHACKS[self.peer] = (
             (FLAGHACKS[self.peer] & ~RpcFlags.QUICKACK) | quickack
@@ -376,7 +376,6 @@ class MTProtoIntermediateFrameStreamReader(LayeredStreamReaderBase):
         msg_len = int.from_bytes(msg_len_bytes, "little")
 
         if msg_len & RpcFlags.QUICKACK.value:
-            # just ignore this for now
             msg_len &= ~RpcFlags.QUICKACK.value
             quickack = RpcFlags.QUICKACK
         else:


### PR DESCRIPTION
The protocol is (partially) described [here](https://core.telegram.org/mtproto#tcp-transport); the flag changes to make middle proxies work are undocumented and completely reverse engineered from the reference implementation. This works with latest Telegram on Android, Messenger Plus, Telegram X beta and TDesktop 1.3.7.

Fixes #25.