### PR TITLE
Add support of setuptools

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+__pycache__/
+*.egg-info/
+build/
+dist/

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,3 @@
+[bdist_wheel]
+universal = 0
+python-tag = py35

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+
+import setuptools
+
+
+with open("README.md", "rt") as readme_fp:
+    long_description = readme_fp.read().strip()
+
+
+setuptools.setup(
+    name="mtprotoproxy",
+    version="1.0",
+    description="Async MTProto Proxy",
+    long_description=long_description,
+    url="https://github.com/alexbers/mtprotoproxy",
+    author="Alexander Bersenev",
+    author_email="bay@hackerdom.ru",
+    maintainer="Alexander Bersenev",
+    maintainer_email="bay@hackerdom.ru",
+    license="MIT",
+    packages=[],
+    install_requires=[
+        "pycryptodome~=3.6,!=3.6.2"
+    ],
+    extras_require={
+        "uvloop": [
+            "uvloop~=0.10.1"
+        ],
+        "pyaes": [
+            "pyaes~=1.6.1"
+        ]
+    },
+    scripts=[
+        "mtprotoproxy.py"
+    ],
+    classifiers=[
+        "Intended Audience :: Information Technology",
+        "Intended Audience :: System Administrators",
+        "Operating System :: POSIX :: Linux",
+        "Programming Language :: Python",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.5"
+        "Programming Language :: Python :: 3.6"
+    ]
+)


### PR DESCRIPTION
This commit brings support of setuptools. It installs pyaes and uvloop as optional packages with extras. You can install uvloop for example with

```console
$ pip install 'mtprotoproxy[uvloop]'
```

or locally with

```console
$ pip install -e '.[uvloop]' (in development mode)
```