### PR TITLE
cast cl_port from str to int

### DIFF
--- a/mtprotoproxy.py
+++ b/mtprotoproxy.py
@@ -728,7 +728,7 @@ class ProxyReqStreamWriter(LayeredStreamWriterBase):
             self.remote_ip_port += socket.inet_pton(socket.AF_INET, cl_ip)
         else:
             self.remote_ip_port = socket.inet_pton(socket.AF_INET6, cl_ip)
-        self.remote_ip_port += int.to_bytes(cl_port, 4, "little")
+        self.remote_ip_port += int.to_bytes(int(cl_port), 4, "little")
 
         if ":" not in my_ip:
             self.our_ip_port = b"\x00" * 10 + b"\xff\xff"


### PR DESCRIPTION
Поставил mtprotoproxy позади nginx и получил ошибку:

File "/etc/mtprotoproxy/mtprotoproxy.py", line 728, in __init__
self.remote_ip_port += int.to_bytes(cl_port, 4, "little")
TypeError: descriptor 'to_bytes' requires a 'int' object but received a 'str'

Возможно это особенность nginx, но в переменной cl_port приходит строка с номером, а не int.
патч явно кастует в int и так все работает.
