### PR TITLE
Update mtprotoproxy.py

### DIFF
--- a/mtprotoproxy.py
+++ b/mtprotoproxy.py
@@ -19,7 +19,9 @@ import signal
 import os
 import stat
 import traceback
+import resource
 
+resource.setrlimit(resource.RLIMIT_NOFILE, (65536, 65536))
 
 TG_DATACENTER_PORT = 443
 


### PR DESCRIPTION
To avoid errors when the proxy is used a lot: 
`IOError:[Errno 24] Too many open files`.