### PR TITLE
add systemd service

### DIFF
--- a/mtprotoproxy.service
+++ b/mtprotoproxy.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=Fast and simple to setup MTProto proxy written in Python
+ConditionFileIsExecutable=/opt/mtprotoproxy/mtprotoproxy.py
+
+[Service]
+Type=simple
+StartLimitInterval=5
+StartLimitBurst=10
+ExecStart=/opt/mtprotoproxy/mtprotoproxy.py
+WorkingDirectory=/opt/mtprotoproxy
+Restart=always
+RestartSec=120
+
+[Install]
+WantedBy=multi-user.target
+


### PR DESCRIPTION
I add a systemd service sample to automatically run proxy  when system startup.

> Suppose you locate mtprotoproxy in `/opt`

```
git clone https://github.com/alexbers/mtprotoproxy.git; cd mtprotoproxy
ln -s /opt/mtprotoproxy/mtprotoproxy.service /etc/systemd/system/
systemctl daemon-reload
systemctl enable --now mtprotoproxy
```
Now you can stop/start mtprotoproxy easily.

```
systemctl stop mtprotoproxy
systemctl start mtprotoproxy
```