### PR TITLE
Fix file permission in Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,10 +4,10 @@ RUN adduser tgproxy -u 10000 -D
 
 RUN apk add --no-cache python3 py3-cryptography ca-certificates libcap
 
-RUN chown -R tgproxy:tgproxy /home/tgproxy
 RUN setcap cap_net_bind_service=+ep /usr/bin/python3.8
 
 COPY mtprotoproxy.py config.py /home/tgproxy/
+RUN chown -R tgproxy:tgproxy /home/tgproxy
 
 USER tgproxy
 


### PR DESCRIPTION
`chown` needs to be done "after" the file copy, otherwise there is no
meaning to do it as /home/tgproxy is default owned by tgproxy already.

Please let me know if it's better to be just removed, I can revise the pull request, thanks!