### PR TITLE
added ability to load time from local time set on original server

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,7 @@ services:
     volumes:
         - ./config.py:/home/tgproxy/config.py
         - ./mtprotoproxy.py:/home/tgproxy/mtprotoproxy.py
+        - /etc/localtime:/etc/localtime:ro
     logging:
         driver: "json-file"
         options:


### PR DESCRIPTION
using this command the local time setting will be pushed to docker as a read-only file so you can use your local time