### PR TITLE
Add Pysocks in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:20.04
 
-RUN apt-get update && apt-get install --no-install-recommends -y python3 python3-uvloop python3-cryptography libcap2-bin ca-certificates && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install --no-install-recommends -y python3 python3-uvloop python3-cryptography python3-socks libcap2-bin ca-certificates && rm -rf /var/lib/apt/lists/*
 RUN setcap cap_net_bind_service=+ep /usr/bin/python3.8
 
 RUN useradd tgproxy -u 10000


### PR DESCRIPTION
It's necessary if using upstream SOCKS5 proxy. 
#143 