### PR TITLE
Hotfix, Change ubuntu version to 22.04 LTS in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:22.10
+FROM ubuntu:22.04
 
 RUN apt-get update && apt-get install --no-install-recommends -y python3 python3-uvloop python3-cryptography python3-socks libcap2-bin ca-certificates && rm -rf /var/lib/apt/lists/*
 RUN setcap cap_net_bind_service=+ep /usr/bin/python3.10


### PR DESCRIPTION
Changed Ubuntu version from 22.10 to 22.04 as 22.10 is removed from repositories and docker build fails